### PR TITLE
FIX CRASH: call getIndexForTarget only when targetSequence is not nil

### DIFF
--- a/Panels.lua
+++ b/Panels.lua
@@ -682,9 +682,10 @@ end
 local function nextSequence()
 	local isDeadEnd = sequence.endSequence or false
 	unloadSequence()
-	
+
+	local targetIndex = targetSequence and getIndexForTarget(targetSequence) or nil
+
 	if targetSequence then
-		local targetIndex = getIndexForTarget(targetSequence)
 		loadSequence(targetIndex)
 		targetSequence = nil
 		updateMenuData(sequences, gameDidFinish, currentSeqIndex > 1)
@@ -695,7 +696,6 @@ local function nextSequence()
 	elseif isCutscene then
 		playdate.inputHandlers.pop()
 		gameDidFinish = true
-		local targetIndex = getIndexForTarget(targetSequence)
 		cutsceneFinishCallback(targetIndex)
 		Panels.Audio.killBGAudio()
 		previousBGColor = nil -- prevent future cross-fade attempt


### PR DESCRIPTION
A crash introduced in Panels 2.0 occurs when a cutscene ends without a targetSequence.

The cause is that getIndexForTarget is called even when targetSequence is nil

In this PR, a nil check is added to prevent a crash. I did not test this with a branching storyline, only that the original behavior of calling the callback with nil is restored.

Please consider wether this is merely a workaround or an actual fix